### PR TITLE
[FIX] Onchange: compare changes using === operator

### DIFF
--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -636,7 +636,7 @@ instance.web.FormView = instance.web.View.extend(instance.web.form.FieldManagerM
             // If field is not defined in the view, just ignore it
             if (field) {
                 var value_ = values[f];
-                if (field.get_value() != value_) {
+                if (field.get_value() !== value_) {
                     field._inhibit_on_change_flag = true;
                     field.set_value(value_);
                     field._inhibit_on_change_flag = false;


### PR DESCRIPTION
Impacted versions:
 - 8.0

Steps to reproduce:
 1. create an object with a char field
 2. add an onchange method that returns the string "0000" as a value of that field
 3. trigger the onchange

Current behavior:
 - The field stays empty / null

Expected behavior:
 - The field changes to "0000"

This patches changes the comparison to use the === operator, therefore treating `"0000"` as not equal to `false`, and therefore correctly updating the field value.